### PR TITLE
Propose patch for CPANTESTER fail report.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl', '5.008001';
+requires 'perl', '5.10.0';
 
 requires 'Parse::ErrorString::Perl';
 requires 'Term::ANSIColor';

--- a/lib/App/PPE.pm
+++ b/lib/App/PPE.pm
@@ -1,5 +1,5 @@
 package App::PPE;
-use 5.008001;
+use 5.10;
 use strict;
 use warnings;
 


### PR DESCRIPTION
Hi @kfly8 

Please review the PR.

The use logical or operator // was introduced in Perl v5.10. There we see FAIL reports on platform having Perl v5.8. So the simple fix is to upgrade the minimum perl requirement to v5.10.

        https://www.cpantesters.org/cpan/report/308d01ea-d763-11e7-bba1-b275c4fe1824
        https://www.cpantesters.org/cpan/report/28fca39c-dd29-11e7-a1cf-bb670eaac09d

Many Thanks.
Best Regards,
Mohammad S Anwar